### PR TITLE
Fix vignette setup typo (warninge -> warning)

### DIFF
--- a/vignettes/TRADEtools-intro.Rmd
+++ b/vignettes/TRADEtools-intro.Rmd
@@ -11,7 +11,7 @@ vignette: >
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(
-  warninge = FALSE,
+  warning = FALSE,
   collapse = TRUE,
   comment = "#>")
   


### PR DESCRIPTION
This PR fixes a typo in the vignette setup chunk:

warninge = FALSE

should be:

warning = FALSE

The typo can cause installation failures on some systems during vignette processing.